### PR TITLE
Update baseConfig.yml to include UHD results

### DIFF
--- a/core/src/main/resources/config/baseConfig.yml
+++ b/core/src/main/resources/config/baseConfig.yml
@@ -147,6 +147,7 @@ categoriesConfig:
       applySizeLimitsToApi: false
       newznabCategories:
         - "2040"
+        - "2045"
         - "2050"
         - "2060"
         - "2070"
@@ -224,6 +225,7 @@ categoriesConfig:
       applySizeLimitsToApi: false
       newznabCategories:
         - "5040"
+        - "5045"
       requiredRegex: null
       requiredWords: []
       preselect: true


### PR DESCRIPTION
UHD is a subset of HD, so it arguably makes sense to include 4k results when searching for HD (instead of creating a new category).